### PR TITLE
configure k8s CI step for self-hosted

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,3 +36,17 @@ jobs:
           target: production
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  deployment:
+    needs: build
+    runs-on:
+      - self-hosted
+      - auth-service-k8s
+    steps:
+      - name: Rollout restart
+        run: |
+          set -ex
+          cd $HOME
+          wget https://dl.k8s.io/release/v1.26.0/bin/linux/arm64/kubectl
+          chmod +x ./kubectl
+          ~/kubectl rollout restart deployment auth-service-v1 -n default


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a deployment step to the Docker workflow that restarts a Kubernetes deployment after a successful build.

### Detailed summary
- Added deployment step to Docker workflow
- Restart Kubernetes deployment after successful build
- Uses kubectl to rollout restart the `auth-service-v1` deployment in the `default` namespace

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->